### PR TITLE
chore: migrating to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up node
         uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
       - name: Update npm
         run: npm install -g npm@latest # Ensure npm 11.5.1 or later is installed for OIDC support
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,16 @@ jobs:
     needs: [ compile, test ]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for pushing tags
+      id-token: write # required for OIDC
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+      - name: Update npm
+        run: npm install -g npm@latest # Ensure npm 11.5.1 or later is installed for OIDC support
       - name: Install dependencies
         run: yarn install
       - name: Build
@@ -53,5 +58,3 @@ jobs:
           else
             npm publish --access public
           fi
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Publish to npm
         run: |
-          npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           if [[ ${GITHUB_REF} == *alpha* ]]; then
             npm publish --access public --tag alpha
           elif [[ ${GITHUB_REF} == *beta* ]]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opengovsg/refx-ts-sdk",
-    "version": "0.0.0-develop-alpha-1762754615",
+    "version": "0.0.54",
     "private": false,
     "repository": "https://github.com/opengovsg/refer-ts-sdk",
     "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opengovsg/refx-ts-sdk",
-    "version": "0.0.54",
+    "version": "0.0.0-develop-alpha-1762754615",
     "private": false,
     "repository": "https://github.com/opengovsg/refer-ts-sdk",
     "main": "./index.js",


### PR DESCRIPTION
## Problem

NPM tokens will soon be limited to have a max life of 3 months. Following the [internal guide](https://www.notion.so/opengov/Use-OIDC-for-NPM-publishing-29377dbba7888076a428d2d4d38697e6?source=copy_link) to migrating to OIDC.

## Solution

Followed steps in the [internal guide ](https://www.notion.so/opengov/Use-OIDC-for-NPM-publishing-29377dbba7888076a428d2d4d38697e6?source=copy_link). This PR updated GitHub action by referencing the [sample PR.](https://github.com/opengovsg/eslint-config-opengovsg/pull/21/files)

## Tests
Bumped SDK to a developer version and tested the [publish action run](https://github.com/opengovsg/refer-ts-sdk/actions/runs/19224285483/job/54948032955).
<img width="1217" height="743" alt="Screenshot 2025-11-10 at 3 47 39 PM" src="https://github.com/user-attachments/assets/d94b125a-2c54-42b3-90e7-ed6b43c9de52" />


## Deploy Notes

NA

