### PR TITLE
feat: jwt sub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opengovsg/refx-ts-sdk",
-    "version": "0.0.0-develop-alpha-1763534116",
+    "version": "0.0.0-develop-alpha-1763535866",
     "private": false,
     "repository": "https://github.com/opengovsg/refer-ts-sdk",
     "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@opengovsg/refx-ts-sdk",
-    "version": "0.0.0-develop-alpha-1763450943",
+    "version": "0.0.0-develop-alpha-1763534116",
     "private": false,
     "repository": "https://github.com/opengovsg/refer-ts-sdk",
     "main": "./index.js",

--- a/src/wrapper/ReferralExchangeJwtClient.ts
+++ b/src/wrapper/ReferralExchangeJwtClient.ts
@@ -107,17 +107,18 @@ function createSignedJwt({ privateKey, issuer, subject }: CreateSignedJwtArgs): 
 } {
     const issuedAt = Math.floor(Date.now() / 1000);
     const expiresAtEpochSeconds = issuedAt + JWT_TTL_SECONDS;
+    const signOptions: jwt.SignOptions = {
+        algorithm: "ES256",
+        issuer,
+        expiresIn: JWT_TTL_SECONDS,
+    };
 
-    const token = jwt.sign(
-        {},
-        privateKey,
-        {
-            algorithm: "ES256",
-            issuer,
-            expiresIn: JWT_TTL_SECONDS,
-            subject,
-        },
-    );
+    // Only add the claim if a value is provided(not null or undefined) 
+    if (subject != null) {
+        signOptions.subject = subject;
+    }
+
+    const token = jwt.sign({}, privateKey, signOptions);
 
     return {
         token,

--- a/tests/unit/wrapper/ReferralExchangeJwtClient.test.ts
+++ b/tests/unit/wrapper/ReferralExchangeJwtClient.test.ts
@@ -57,6 +57,28 @@ describe("ReferralExchangeJwtClient", () => {
         );
     });
 
+    it("omits subject claim when not provided", async () => {
+        signMock.mockReturnValue("token-1");
+
+        const client = new ReferralExchangeJwtClient({
+            privateKey: "fake-private-key",
+            apiKeyName: "issuer",
+        });
+
+        const fetcher = ((client as any)._options.fetcher) as (args: typeof requestArgs) => Promise<unknown>;
+
+        await fetcher(requestArgs);
+
+        const [, , options] = signMock.mock.calls[0];
+        expect(options).toEqual(
+            expect.objectContaining({
+                issuer: "issuer",
+                algorithm: "ES256",
+            }),
+        );
+        expect(options).not.toHaveProperty("subject");
+    });
+
     it("includes subject claim when provided", async () => {
         signMock.mockReturnValue("token-1");
 

--- a/tests/unit/wrapper/ReferralExchangeJwtClient.test.ts
+++ b/tests/unit/wrapper/ReferralExchangeJwtClient.test.ts
@@ -57,6 +57,29 @@ describe("ReferralExchangeJwtClient", () => {
         );
     });
 
+    it("includes subject claim when provided", async () => {
+        signMock.mockReturnValue("token-1");
+
+        const client = new ReferralExchangeJwtClient({
+            privateKey: "fake-private-key",
+            apiKeyName: "issuer",
+            subject: "user-123",
+        });
+
+        const fetcher = ((client as any)._options.fetcher) as (args: typeof requestArgs) => Promise<unknown>;
+
+        await fetcher(requestArgs);
+
+        expect(signMock).toHaveBeenCalledWith(
+            {},
+            "fake-private-key",
+            expect.objectContaining({
+                issuer: "issuer",
+                subject: "user-123",
+            }),
+        );
+    });
+
     it("reuses cached tokens until the refresh buffer elapses", async () => {
         signMock.mockReturnValueOnce("token-1").mockReturnValueOnce("token-2");
 


### PR DESCRIPTION
## Problem

We added JWT `sub` claim support in https://github.com/opengovsg/refer/pull/968. This PR implemented the signing logic in client SDK.

Closes REFX-622.

## Solution

Added `subject` as an optional param in client initialization.

## Tests

- [x] Published a dev version and tested in HAS local env for the below cases:
    * only `iss`
    * `iss` with valid `sub`
    * `iss` with invalid `sub`

## Deploy Notes

NA