### PR TITLE
chore: publish to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,8 @@ jobs:
           elif [[ ${GITHUB_REF} == *beta* ]]; then
             npm publish --access public --tag beta
           else
-            npm publish --access public
+            npm publish --access public --tag stable
+            PKG_NAME=$(node -p "require('./package.json').name")
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            npm dist-tag add ${PKG_NAME}@${PKG_VERSION} latest
           fi


### PR DESCRIPTION
## Problem

CI started failing two months ago due to:
```
npm error Cannot implicitly apply the "latest" tag because previously published version 2025.2.21 is higher than the new version 0.0.59. You must specify a tag using --tag.
```

`2025.2.21` is due to a legacy version that's not consistent with current naming convention. Suspect NPM might had a change to sort versions.

## Solution

Change `ci.yaml` to publish with `stable` tag first and explicitly set to latest